### PR TITLE
fix: Changed Initial State Interface Definition

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,9 +40,7 @@ export interface SagaObject {
 
 interface RequiredModuleOpts<StoreState> {
     name: string,
-    initialState: {
-        [key: string]: any
-    },
+    initialState: StoreState,
     reducers: {
         [key: string]: (state: StoreState, payload) => void
     }


### PR DESCRIPTION
Slice state interface should now be inferred by the type of the initial state. Type checking should now occur on the initial state. Aligns with what is possible in redux toolkit.